### PR TITLE
Update launch configs for new target platform

### DIFF
--- a/backend/plugins/com.eclipsesource.coffee.workflow.analyzer.application/WorkflowAnalyzerServer.launch
+++ b/backend/plugins/com.eclipsesource.coffee.workflow.analyzer.application/WorkflowAnalyzerServer.launch
@@ -34,10 +34,13 @@
         <setEntry value="com.fasterxml.jackson.core.jackson-databind@default:default"/>
         <setEntry value="com.google.gson*2.8.2.v20180104-1110@default:default"/>
         <setEntry value="com.google.guava@default:default"/>
+        <setEntry value="com.google.inject.multibindings@default:default"/>
         <setEntry value="com.google.inject@default:default"/>
         <setEntry value="com.ibm.icu@default:default"/>
         <setEntry value="com.jcraft.jsch@default:default"/>
         <setEntry value="com.sun.el@default:default"/>
+        <setEntry value="com.sun.jna.platform@default:default"/>
+        <setEntry value="com.sun.jna@default:default"/>
         <setEntry value="io.github.classgraph@default:default"/>
         <setEntry value="javax.annotation@default:default"/>
         <setEntry value="javax.el@default:default"/>
@@ -84,10 +87,8 @@
         <setEntry value="org.eclipse.core.expressions@default:default"/>
         <setEntry value="org.eclipse.core.externaltools@default:default"/>
         <setEntry value="org.eclipse.core.filebuffers@default:default"/>
-        <setEntry value="org.eclipse.core.filesystem.linux.x86_64@default:false"/>
         <setEntry value="org.eclipse.core.filesystem@default:default"/>
         <setEntry value="org.eclipse.core.jobs@default:default"/>
-        <setEntry value="org.eclipse.core.net.linux.x86_64@default:false"/>
         <setEntry value="org.eclipse.core.net@default:default"/>
         <setEntry value="org.eclipse.core.resources@default:default"/>
         <setEntry value="org.eclipse.core.runtime@default:true"/>
@@ -109,9 +110,9 @@
         <setEntry value="org.eclipse.e4.ui.css.swt@default:default"/>
         <setEntry value="org.eclipse.e4.ui.di@default:default"/>
         <setEntry value="org.eclipse.e4.ui.dialogs@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.ide@default:default"/>
         <setEntry value="org.eclipse.e4.ui.model.workbench@default:default"/>
         <setEntry value="org.eclipse.e4.ui.services@default:default"/>
-        <setEntry value="org.eclipse.e4.ui.swt.gtk@default:false"/>
         <setEntry value="org.eclipse.e4.ui.widgets@default:default"/>
         <setEntry value="org.eclipse.e4.ui.workbench.addons.swt@default:default"/>
         <setEntry value="org.eclipse.e4.ui.workbench.renderers.swt@default:default"/>
@@ -171,6 +172,7 @@
         <setEntry value="org.eclipse.emfcloud.modelserver.client@default:default"/>
         <setEntry value="org.eclipse.emfcloud.modelserver.common@default:default"/>
         <setEntry value="org.eclipse.emfcloud.modelserver.edit@default:default"/>
+        <setEntry value="org.eclipse.emfcloud.modelserver.emf@default:default"/>
         <setEntry value="org.eclipse.emfcloud.modelserver.lib@default:default"/>
         <setEntry value="org.eclipse.equinox.app@default:default"/>
         <setEntry value="org.eclipse.equinox.bidi@default:default"/>
@@ -185,7 +187,6 @@
         <setEntry value="org.eclipse.equinox.http.servlet@default:default"/>
         <setEntry value="org.eclipse.equinox.jsp.jasper.registry@default:default"/>
         <setEntry value="org.eclipse.equinox.jsp.jasper@default:default"/>
-        <setEntry value="org.eclipse.equinox.launcher.gtk.linux.x86_64@default:false"/>
         <setEntry value="org.eclipse.equinox.launcher@default:default"/>
         <setEntry value="org.eclipse.equinox.p2.artifact.repository@default:default"/>
         <setEntry value="org.eclipse.equinox.p2.console@default:default"/>
@@ -216,7 +217,6 @@
         <setEntry value="org.eclipse.equinox.p2.updatesite@default:default"/>
         <setEntry value="org.eclipse.equinox.preferences@default:default"/>
         <setEntry value="org.eclipse.equinox.registry@default:default"/>
-        <setEntry value="org.eclipse.equinox.security.linux.x86_64@default:false"/>
         <setEntry value="org.eclipse.equinox.security.ui@default:default"/>
         <setEntry value="org.eclipse.equinox.security@default:default"/>
         <setEntry value="org.eclipse.equinox.simpleconfigurator.manipulator@default:default"/>
@@ -256,7 +256,12 @@
         <setEntry value="org.eclipse.jetty.servlet*9.4.34.v20201102@default:default"/>
         <setEntry value="org.eclipse.jetty.util*9.4.31.v20200723@default:default"/>
         <setEntry value="org.eclipse.jetty.util*9.4.34.v20201102@default:default"/>
+        <setEntry value="org.eclipse.jetty.websocket.api@default:default"/>
+        <setEntry value="org.eclipse.jetty.websocket.common@default:default"/>
+        <setEntry value="org.eclipse.jetty.websocket.server@default:default"/>
+        <setEntry value="org.eclipse.jetty.websocket.servlet@default:default"/>
         <setEntry value="org.eclipse.jface.databinding@default:default"/>
+        <setEntry value="org.eclipse.jface.notifications@default:default"/>
         <setEntry value="org.eclipse.jface.text@default:default"/>
         <setEntry value="org.eclipse.jface@default:default"/>
         <setEntry value="org.eclipse.jsch.core@default:default"/>
@@ -296,7 +301,6 @@
         <setEntry value="org.eclipse.platform@default:default"/>
         <setEntry value="org.eclipse.rcp@default:default"/>
         <setEntry value="org.eclipse.search@default:default"/>
-        <setEntry value="org.eclipse.swt.gtk.linux.x86_64@default:false"/>
         <setEntry value="org.eclipse.swt@default:default"/>
         <setEntry value="org.eclipse.team.core@default:default"/>
         <setEntry value="org.eclipse.team.genericeditor.diff.extension@default:default"/>
@@ -403,6 +407,7 @@
         <setEntry value="org.opentest4j@default:default"/>
         <setEntry value="org.sat4j.core@default:default"/>
         <setEntry value="org.sat4j.pb@default:default"/>
+        <setEntry value="org.slf4j.api@default:default"/>
         <setEntry value="org.tukaani.xz@default:default"/>
         <setEntry value="org.w3c.css.sac@default:default"/>
         <setEntry value="org.w3c.dom.events@default:default"/>

--- a/backend/plugins/com.eclipsesource.workflow.dsl.ide/RunSocketServer-Headless.launch
+++ b/backend/plugins/com.eclipsesource.workflow.dsl.ide/RunSocketServer-Headless.launch
@@ -1,145 +1,160 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
-<booleanAttribute key="append.args" value="true"/>
-<booleanAttribute key="askclear" value="false"/>
-<booleanAttribute key="automaticAdd" value="false"/>
-<booleanAttribute key="automaticValidate" value="false"/>
-<stringAttribute key="bootstrap" value=""/>
-<stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="true"/>
-<booleanAttribute key="clearws" value="true"/>
-<booleanAttribute key="clearwslog" value="false"/>
-<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/RunSocketServer-Headless"/>
-<booleanAttribute key="default" value="false"/>
-<setAttribute key="deselected_workspace_bundles"/>
-<booleanAttribute key="includeOptional" value="false"/>
-<stringAttribute key="location" value="${workspace_loc}/../runtime-headless"/>
-<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -startSocket"/>
-<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="pde.version" value="3.3"/>
-<stringAttribute key="product" value="com.eclipsesource.workflow.dsl.ide.product"/>
-<setAttribute key="selected_target_bundles">
-<setEntry value="com.eclipsesource.modelserver.coffee.model@default:default"/>
-<setEntry value="com.fasterxml.jackson.core.jackson-annotations@default:default"/>
-<setEntry value="com.fasterxml.jackson.core.jackson-core@default:default"/>
-<setEntry value="com.fasterxml.jackson.core.jackson-databind@default:default"/>
-<setEntry value="com.google.gson*2.8.2.v20180104-1110@default:default"/>
-<setEntry value="com.google.guava@default:default"/>
-<setEntry value="com.google.inject@default:default"/>
-<setEntry value="com.ibm.icu@default:default"/>
-<setEntry value="io.github.classgraph@default:default"/>
-<setEntry value="javax.annotation@default:default"/>
-<setEntry value="javax.inject@default:default"/>
-<setEntry value="org.antlr.runtime@default:default"/>
-<setEntry value="org.apache.batik.constants@default:default"/>
-<setEntry value="org.apache.batik.css@default:default"/>
-<setEntry value="org.apache.batik.i18n@default:default"/>
-<setEntry value="org.apache.batik.util@default:default"/>
-<setEntry value="org.apache.commons.io*2.6.0.v20190123-2029@default:default"/>
-<setEntry value="org.apache.commons.jxpath@default:default"/>
-<setEntry value="org.apache.commons.logging@default:default"/>
-<setEntry value="org.apache.felix.gogo.command@default:default"/>
-<setEntry value="org.apache.felix.gogo.runtime@default:default"/>
-<setEntry value="org.apache.felix.gogo.shell@default:default"/>
-<setEntry value="org.apache.felix.scr@1:true"/>
-<setEntry value="org.apache.log4j@default:default"/>
-<setEntry value="org.apache.xmlgraphics@default:default"/>
-<setEntry value="org.eclipse.ant.core@default:default"/>
-<setEntry value="org.eclipse.compare.core@default:default"/>
-<setEntry value="org.eclipse.core.commands@default:default"/>
-<setEntry value="org.eclipse.core.contenttype@default:default"/>
-<setEntry value="org.eclipse.core.databinding.observable@default:default"/>
-<setEntry value="org.eclipse.core.databinding.property@default:default"/>
-<setEntry value="org.eclipse.core.databinding@default:default"/>
-<setEntry value="org.eclipse.core.expressions@default:default"/>
-<setEntry value="org.eclipse.core.filesystem.linux.x86_64@default:false"/>
-<setEntry value="org.eclipse.core.filesystem@default:default"/>
-<setEntry value="org.eclipse.core.jobs@default:default"/>
-<setEntry value="org.eclipse.core.resources@default:default"/>
-<setEntry value="org.eclipse.core.runtime@default:true"/>
-<setEntry value="org.eclipse.core.variables@default:default"/>
-<setEntry value="org.eclipse.e4.core.commands@default:default"/>
-<setEntry value="org.eclipse.e4.core.contexts@default:default"/>
-<setEntry value="org.eclipse.e4.core.di.annotations@default:default"/>
-<setEntry value="org.eclipse.e4.core.di.extensions.supplier@default:default"/>
-<setEntry value="org.eclipse.e4.core.di.extensions@default:default"/>
-<setEntry value="org.eclipse.e4.core.di@default:default"/>
-<setEntry value="org.eclipse.e4.core.services@default:default"/>
-<setEntry value="org.eclipse.e4.emf.xpath@default:default"/>
-<setEntry value="org.eclipse.e4.ui.bindings@default:default"/>
-<setEntry value="org.eclipse.e4.ui.css.core@default:default"/>
-<setEntry value="org.eclipse.e4.ui.css.swt.theme@default:default"/>
-<setEntry value="org.eclipse.e4.ui.css.swt@default:default"/>
-<setEntry value="org.eclipse.e4.ui.di@default:default"/>
-<setEntry value="org.eclipse.e4.ui.dialogs@default:default"/>
-<setEntry value="org.eclipse.e4.ui.model.workbench@default:default"/>
-<setEntry value="org.eclipse.e4.ui.services@default:default"/>
-<setEntry value="org.eclipse.e4.ui.swt.gtk@default:false"/>
-<setEntry value="org.eclipse.e4.ui.widgets@default:default"/>
-<setEntry value="org.eclipse.e4.ui.workbench.addons.swt@default:default"/>
-<setEntry value="org.eclipse.e4.ui.workbench.renderers.swt@default:default"/>
-<setEntry value="org.eclipse.e4.ui.workbench.swt@default:default"/>
-<setEntry value="org.eclipse.e4.ui.workbench3@default:default"/>
-<setEntry value="org.eclipse.e4.ui.workbench@default:default"/>
-<setEntry value="org.eclipse.emf.common@default:default"/>
-<setEntry value="org.eclipse.emf.ecore.change@default:default"/>
-<setEntry value="org.eclipse.emf.ecore.xmi@default:default"/>
-<setEntry value="org.eclipse.emf.ecore@default:default"/>
-<setEntry value="org.eclipse.emf.edit@default:default"/>
-<setEntry value="org.eclipse.emfcloud.modelserver.client@default:default"/>
-<setEntry value="org.eclipse.emfcloud.modelserver.common@default:default"/>
-<setEntry value="org.eclipse.emfcloud.modelserver.edit@default:default"/>
-<setEntry value="org.eclipse.emfcloud.modelserver.lib@default:default"/>
-<setEntry value="org.eclipse.equinox.app@default:default"/>
-<setEntry value="org.eclipse.equinox.common@2:true"/>
-<setEntry value="org.eclipse.equinox.event@default:default"/>
-<setEntry value="org.eclipse.equinox.preferences@default:default"/>
-<setEntry value="org.eclipse.equinox.registry@default:default"/>
-<setEntry value="org.eclipse.help@default:default"/>
-<setEntry value="org.eclipse.jface.databinding@default:default"/>
-<setEntry value="org.eclipse.jface@default:default"/>
-<setEntry value="org.eclipse.lsp4j.jsonrpc@default:default"/>
-<setEntry value="org.eclipse.lsp4j@default:default"/>
-<setEntry value="org.eclipse.osgi.compatibility.state@default:false"/>
-<setEntry value="org.eclipse.osgi.services@default:default"/>
-<setEntry value="org.eclipse.osgi.util@default:default"/>
-<setEntry value="org.eclipse.osgi@-1:true"/>
-<setEntry value="org.eclipse.pde.ds.lib@default:default"/>
-<setEntry value="org.eclipse.swt.gtk.linux.x86_64@default:false"/>
-<setEntry value="org.eclipse.swt@default:default"/>
-<setEntry value="org.eclipse.team.core@default:default"/>
-<setEntry value="org.eclipse.ui.trace@default:default"/>
-<setEntry value="org.eclipse.ui.workbench@default:default"/>
-<setEntry value="org.eclipse.ui@default:default"/>
-<setEntry value="org.eclipse.xtend.lib.macro@default:default"/>
-<setEntry value="org.eclipse.xtend.lib@default:default"/>
-<setEntry value="org.eclipse.xtext.common.types@default:default"/>
-<setEntry value="org.eclipse.xtext.ide@default:default"/>
-<setEntry value="org.eclipse.xtext.logging@default:false"/>
-<setEntry value="org.eclipse.xtext.util@default:default"/>
-<setEntry value="org.eclipse.xtext.xbase.ide@default:default"/>
-<setEntry value="org.eclipse.xtext.xbase.lib@default:default"/>
-<setEntry value="org.eclipse.xtext.xbase@default:default"/>
-<setEntry value="org.eclipse.xtext@default:default"/>
-<setEntry value="org.emfjson.jackson@default:default"/>
-<setEntry value="org.objectweb.asm@default:default"/>
-<setEntry value="org.w3c.css.sac@default:default"/>
-<setEntry value="org.w3c.dom.events@default:default"/>
-<setEntry value="org.w3c.dom.smil@default:default"/>
-<setEntry value="org.w3c.dom.svg@default:default"/>
-</setAttribute>
-<setAttribute key="selected_workspace_bundles">
-<setEntry value="com.eclipsesource.coffee.common@default:default"/>
-<setEntry value="com.eclipsesource.workflow.dsl.ide@default:default"/>
-<setEntry value="com.eclipsesource.workflow.dsl@default:default"/>
-</setAttribute>
-<booleanAttribute key="show_selected_only" value="false"/>
-<stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
-<booleanAttribute key="tracing" value="false"/>
-<booleanAttribute key="useCustomFeatures" value="false"/>
-<booleanAttribute key="useDefaultConfig" value="true"/>
-<booleanAttribute key="useDefaultConfigArea" value="true"/>
-<booleanAttribute key="useProduct" value="true"/>
+    <booleanAttribute key="append.args" value="true"/>
+    <booleanAttribute key="askclear" value="false"/>
+    <booleanAttribute key="automaticAdd" value="false"/>
+    <booleanAttribute key="automaticValidate" value="false"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="true"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/RunSocketServer-Headless"/>
+    <booleanAttribute key="default" value="false"/>
+    <setAttribute key="deselected_workspace_bundles"/>
+    <booleanAttribute key="includeOptional" value="false"/>
+    <stringAttribute key="location" value="${workspace_loc}/../runtime-headless"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -startSocket"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="com.eclipsesource.workflow.dsl.ide.product"/>
+    <setAttribute key="selected_target_bundles">
+        <setEntry value="com.eclipsesource.modelserver.coffee.model@default:default"/>
+        <setEntry value="com.fasterxml.jackson.core.jackson-annotations@default:default"/>
+        <setEntry value="com.fasterxml.jackson.core.jackson-core@default:default"/>
+        <setEntry value="com.fasterxml.jackson.core.jackson-databind@default:default"/>
+        <setEntry value="com.google.gson*2.8.2.v20180104-1110@default:default"/>
+        <setEntry value="com.google.guava@default:default"/>
+        <setEntry value="com.google.inject.multibindings@default:default"/>
+        <setEntry value="com.google.inject@default:default"/>
+        <setEntry value="com.ibm.icu@default:default"/>
+        <setEntry value="com.sun.jna.platform@default:default"/>
+        <setEntry value="com.sun.jna@default:default"/>
+        <setEntry value="io.github.classgraph@default:default"/>
+        <setEntry value="javax.annotation@default:default"/>
+        <setEntry value="javax.inject@default:default"/>
+        <setEntry value="javax.servlet@default:default"/>
+        <setEntry value="org.antlr.runtime@default:default"/>
+        <setEntry value="org.apache.batik.constants@default:default"/>
+        <setEntry value="org.apache.batik.css@default:default"/>
+        <setEntry value="org.apache.batik.i18n@default:default"/>
+        <setEntry value="org.apache.batik.util@default:default"/>
+        <setEntry value="org.apache.commons.io*2.6.0.v20190123-2029@default:default"/>
+        <setEntry value="org.apache.commons.jxpath@default:default"/>
+        <setEntry value="org.apache.commons.logging@default:default"/>
+        <setEntry value="org.apache.felix.gogo.command@default:default"/>
+        <setEntry value="org.apache.felix.gogo.runtime@default:default"/>
+        <setEntry value="org.apache.felix.gogo.shell@default:default"/>
+        <setEntry value="org.apache.felix.scr@1:true"/>
+        <setEntry value="org.apache.log4j@default:default"/>
+        <setEntry value="org.apache.xmlgraphics@default:default"/>
+        <setEntry value="org.eclipse.ant.core@default:default"/>
+        <setEntry value="org.eclipse.compare.core@default:default"/>
+        <setEntry value="org.eclipse.core.commands@default:default"/>
+        <setEntry value="org.eclipse.core.contenttype@default:default"/>
+        <setEntry value="org.eclipse.core.databinding.observable@default:default"/>
+        <setEntry value="org.eclipse.core.databinding.property@default:default"/>
+        <setEntry value="org.eclipse.core.databinding@default:default"/>
+        <setEntry value="org.eclipse.core.expressions@default:default"/>
+        <setEntry value="org.eclipse.core.filesystem@default:default"/>
+        <setEntry value="org.eclipse.core.jobs@default:default"/>
+        <setEntry value="org.eclipse.core.resources@default:default"/>
+        <setEntry value="org.eclipse.core.runtime@default:true"/>
+        <setEntry value="org.eclipse.core.variables@default:default"/>
+        <setEntry value="org.eclipse.e4.core.commands@default:default"/>
+        <setEntry value="org.eclipse.e4.core.contexts@default:default"/>
+        <setEntry value="org.eclipse.e4.core.di.annotations@default:default"/>
+        <setEntry value="org.eclipse.e4.core.di.extensions.supplier@default:default"/>
+        <setEntry value="org.eclipse.e4.core.di.extensions@default:default"/>
+        <setEntry value="org.eclipse.e4.core.di@default:default"/>
+        <setEntry value="org.eclipse.e4.core.services@default:default"/>
+        <setEntry value="org.eclipse.e4.emf.xpath@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.bindings@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.css.core@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.css.swt.theme@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.css.swt@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.di@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.dialogs@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.model.workbench@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.services@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.widgets@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.workbench.addons.swt@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.workbench.renderers.swt@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.workbench.swt@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.workbench3@default:default"/>
+        <setEntry value="org.eclipse.e4.ui.workbench@default:default"/>
+        <setEntry value="org.eclipse.emf.common@default:default"/>
+        <setEntry value="org.eclipse.emf.ecore.change@default:default"/>
+        <setEntry value="org.eclipse.emf.ecore.xmi@default:default"/>
+        <setEntry value="org.eclipse.emf.ecore@default:default"/>
+        <setEntry value="org.eclipse.emf.edit@default:default"/>
+        <setEntry value="org.eclipse.emfcloud.modelserver.client@default:default"/>
+        <setEntry value="org.eclipse.emfcloud.modelserver.common@default:default"/>
+        <setEntry value="org.eclipse.emfcloud.modelserver.edit@default:default"/>
+        <setEntry value="org.eclipse.emfcloud.modelserver.emf@default:default"/>
+        <setEntry value="org.eclipse.emfcloud.modelserver.lib@default:default"/>
+        <setEntry value="org.eclipse.equinox.app@default:default"/>
+        <setEntry value="org.eclipse.equinox.common@2:true"/>
+        <setEntry value="org.eclipse.equinox.event@default:default"/>
+        <setEntry value="org.eclipse.equinox.preferences@default:default"/>
+        <setEntry value="org.eclipse.equinox.registry@default:default"/>
+        <setEntry value="org.eclipse.help@default:default"/>
+        <setEntry value="org.eclipse.jetty.http*9.4.34.v20201102@default:default"/>
+        <setEntry value="org.eclipse.jetty.io*9.4.34.v20201102@default:default"/>
+        <setEntry value="org.eclipse.jetty.security*9.4.34.v20201102@default:default"/>
+        <setEntry value="org.eclipse.jetty.server*9.4.34.v20201102@default:default"/>
+        <setEntry value="org.eclipse.jetty.servlet*9.4.34.v20201102@default:default"/>
+        <setEntry value="org.eclipse.jetty.util*9.4.34.v20201102@default:default"/>
+        <setEntry value="org.eclipse.jetty.websocket.api@default:default"/>
+        <setEntry value="org.eclipse.jetty.websocket.common@default:default"/>
+        <setEntry value="org.eclipse.jetty.websocket.server@default:default"/>
+        <setEntry value="org.eclipse.jetty.websocket.servlet@default:default"/>
+        <setEntry value="org.eclipse.jface.databinding@default:default"/>
+        <setEntry value="org.eclipse.jface.notifications@default:default"/>
+        <setEntry value="org.eclipse.jface@default:default"/>
+        <setEntry value="org.eclipse.lsp4j.jsonrpc@default:default"/>
+        <setEntry value="org.eclipse.lsp4j@default:default"/>
+        <setEntry value="org.eclipse.osgi.compatibility.state@default:false"/>
+        <setEntry value="org.eclipse.osgi.services@default:default"/>
+        <setEntry value="org.eclipse.osgi.util@default:default"/>
+        <setEntry value="org.eclipse.osgi@-1:true"/>
+        <setEntry value="org.eclipse.pde.ds.lib@default:default"/>
+        <setEntry value="org.eclipse.swt@default:default"/>
+        <setEntry value="org.eclipse.team.core@default:default"/>
+        <setEntry value="org.eclipse.ui.trace@default:default"/>
+        <setEntry value="org.eclipse.ui.workbench@default:default"/>
+        <setEntry value="org.eclipse.ui@default:default"/>
+        <setEntry value="org.eclipse.urischeme@default:default"/>
+        <setEntry value="org.eclipse.xtend.lib.macro@default:default"/>
+        <setEntry value="org.eclipse.xtend.lib@default:default"/>
+        <setEntry value="org.eclipse.xtext.common.types@default:default"/>
+        <setEntry value="org.eclipse.xtext.ide@default:default"/>
+        <setEntry value="org.eclipse.xtext.logging@default:false"/>
+        <setEntry value="org.eclipse.xtext.util@default:default"/>
+        <setEntry value="org.eclipse.xtext.xbase.ide@default:default"/>
+        <setEntry value="org.eclipse.xtext.xbase.lib@default:default"/>
+        <setEntry value="org.eclipse.xtext.xbase@default:default"/>
+        <setEntry value="org.eclipse.xtext@default:default"/>
+        <setEntry value="org.emfjson.jackson@default:default"/>
+        <setEntry value="org.objectweb.asm@default:default"/>
+        <setEntry value="org.slf4j.api@default:default"/>
+        <setEntry value="org.w3c.css.sac@default:default"/>
+        <setEntry value="org.w3c.dom.events@default:default"/>
+        <setEntry value="org.w3c.dom.smil@default:default"/>
+        <setEntry value="org.w3c.dom.svg@default:default"/>
+    </setAttribute>
+    <setAttribute key="selected_workspace_bundles">
+        <setEntry value="com.eclipsesource.coffee.common@default:default"/>
+        <setEntry value="com.eclipsesource.workflow.dsl.ide@default:default"/>
+        <setEntry value="com.eclipsesource.workflow.dsl@default:default"/>
+    </setAttribute>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="true"/>
+    <booleanAttribute key="useProduct" value="true"/>
 </launchConfiguration>


### PR DESCRIPTION
The new target platform brings in a bunch of new package and bundle requirements that need to be included in shared launch configurations. The changes herein worked for me, to get the back-end services running in the Eclipse development environment.